### PR TITLE
fix: senha de boas-vindas segura

### DIFF
--- a/app/Models/Pessoa.php
+++ b/app/Models/Pessoa.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
 
 class Pessoa extends Model
 {
@@ -53,7 +54,7 @@ class Pessoa extends Model
                 return;
             }
 
-            $senha = $pessoa->dat_nascimento->format('Ymd');
+            $senha = Str::password(16);
 
             $user = User::create([
                 'name' => $pessoa->nom_pessoa,

--- a/tests/Feature/PessoaTest.php
+++ b/tests/Feature/PessoaTest.php
@@ -264,9 +264,11 @@ test('ao criar pessoa sem usuario cria usuario automaticamente', function () {
 
     expect($user)->not->toBeNull()
         ->and($user->email)->toBe('teste@teste.com')
-        ->and(Hash::check('19900101', $user->password))->toBeTrue();
+        ->and($user->password)->not->toBeEmpty();
 
-    Mail::assertSent(BoasVindasMail::class);
+    Mail::assertSent(BoasVindasMail::class, function ($mail) {
+        return ! empty($mail->senhaTemporaria) && strlen($mail->senhaTemporaria) >= 16;
+    });
 });
 
 test('nao cria usuario se pessoa ja possui idt_usuario', function () {


### PR DESCRIPTION
## Ideia

Parar de criar senha inicial a partir da data de nascimento. Essa senha era previsivel e usava um dado pessoal facil de descobrir.

## O que muda

- Troca a senha `YYYYMMDD` por uma senha temporaria gerada com `Str::password(16)`.
- Mantem o envio da senha temporaria pelo e-mail de boas-vindas.
- Mantem o armazenamento com `Hash::make()`.
- Atualiza o teste de pessoa para validar senha temporaria gerada, em vez de comparar com uma data fixa.

## Em implementacao / pontos de atencao

- Usuarios antigos com senha baseada em data de nascimento nao mudam neste PR.
- Depois, vale criar uma etapa separada para forcar troca de senha ou reset dos usuarios ja existentes.
- Conferir o template do e-mail para garantir que simbolos da senha aparecem bem.

## Validacao

- Rodar `php artisan test --filter=PessoaTest`.
- Criar uma pessoa nova e conferir o e-mail de boas-vindas.
- Entrar com a senha temporaria recebida.