### PR TITLE
feat: enfileira emails de boas-vindas e aniversario

### DIFF
--- a/app/Mail/AniversarioMail.php
+++ b/app/Mail/AniversarioMail.php
@@ -3,12 +3,13 @@
 namespace App\Mail;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-class AniversarioMail extends Mailable
+class AniversarioMail extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 

--- a/app/Mail/BoasVindasMail.php
+++ b/app/Mail/BoasVindasMail.php
@@ -4,6 +4,7 @@ namespace App\Mail;
 
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Attachment;
@@ -11,7 +12,7 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-class BoasVindasMail extends Mailable
+class BoasVindasMail extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 


### PR DESCRIPTION
## Ideia

Colocar os e-mails de boas-vindas e aniversario na fila. Assim o cadastro de pessoa e o comando diario de aniversarios nao ficam presos esperando resposta do SMTP.

## O que muda

- `BoasVindasMail` passa a implementar `ShouldQueue`.
- `AniversarioMail` passa a implementar `ShouldQueue`.
- Os pontos que chamam `Mail::to(...)->send(...)` continuam iguais; o Laravel coloca o envio na fila por causa do contrato `ShouldQueue`.

## Em implementacao / pontos de atencao

- Producao precisa ter worker de fila rodando, por exemplo `php artisan queue:work` com Supervisor ou systemd.
- Se `QUEUE_CONNECTION=sync`, o envio continua bloqueando como antes.
- Depois do deploy, rodar `php artisan queue:restart` para recarregar os workers.

## Validacao

- Rodar testes que usam `Mail::fake()` para cadastro/aniversario.
- Em staging, cadastrar uma pessoa e confirmar que o job entra na fila.
- Rodar o worker e confirmar entrega do e-mail.