### PR TITLE
refactor: extrai validacao de contato para FormRequest

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ContatoRequest;
 use App\Models\Contato;
 use App\Models\Evento;
 use App\Models\Ficha;
@@ -52,7 +53,7 @@ class HomeController extends Controller
         return view('welcome', compact('proximoseventos', 'movimentos'));
     }
 
-    public function contato(Request $request)
+    public function contato(ContatoRequest $request)
     {
         $start = microtime(true);
         $context = $this->getLogContext(request());
@@ -61,13 +62,7 @@ class HomeController extends Controller
             'contato_movimento' => $request->input('idt_movimento'),
         ]));
 
-        $data = $request->validate([
-            'nom_contato' => 'required|string|max:255',
-            'eml_contato' => 'nullable|email|max:255',
-            'tel_contato' => 'required|string|max:20',
-            'txt_mensagem' => 'required|string|max:1000',
-            'idt_movimento' => 'required|exists:tipo_movimento,idt_movimento',
-        ]);
+        $data = $request->validated();
 
         Contato::create($data);
 

--- a/app/Http/Requests/ContatoRequest.php
+++ b/app/Http/Requests/ContatoRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ContatoRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'nom_contato' => 'required|string|max:255',
+            'eml_contato' => 'nullable|email|max:255',
+            'tel_contato' => 'required|string|max:20',
+            'txt_mensagem' => 'required|string|max:1000',
+            'idt_movimento' => 'required|exists:tipo_movimento,idt_movimento',
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'nom_contato.required' => 'O nome é obrigatório.',
+            'nom_contato.max' => 'O nome não pode ter mais de 255 caracteres.',
+            'eml_contato.email' => 'Informe um e-mail válido.',
+            'eml_contato.max' => 'O e-mail não pode ter mais de 255 caracteres.',
+            'tel_contato.required' => 'O telefone é obrigatório.',
+            'tel_contato.max' => 'O telefone não pode ter mais de 20 caracteres.',
+            'txt_mensagem.required' => 'A mensagem é obrigatória.',
+            'txt_mensagem.max' => 'A mensagem não pode ter mais de 1000 caracteres.',
+            'idt_movimento.required' => 'O movimento é obrigatório.',
+            'idt_movimento.exists' => 'O movimento selecionado não é válido.',
+        ];
+    }
+}


### PR DESCRIPTION
## Ideia

Tirar a validacao do formulario de contato de dentro do controller e colocar em um FormRequest. O comportamento continua o mesmo, mas o controller fica menor e a validacao fica no lugar certo.

## O que muda

- Cria `app/Http/Requests/ContatoRequest.php` com `authorize()`, `rules()` e mensagens em portugues.
- Atualiza `HomeController@contato` para receber `ContatoRequest`.
- Troca `$request->validate(...)` por `$request->validated()`.
- Mantem as mesmas regras para nome, e-mail, telefone, mensagem e movimento.

## Em implementacao / pontos de atencao

- E um refactor. Nao muda rota, tela ou regra de negocio.
- O objetivo e seguir o mesmo padrao ja usado em outros requests do projeto.

## Validacao

- Enviar contato valido pela Home.
- Enviar contato sem campos obrigatorios e conferir mensagens.
- Rodar a suite ou pelo menos os testes do fluxo de contato.