### PR TITLE
fix(fichas): corrigir contraste dos badges de situação nos formulários VEM, ECC e SGM

### DIFF
--- a/app/Enums/CorTroca.php
+++ b/app/Enums/CorTroca.php
@@ -31,4 +31,15 @@ enum CorTroca: string
             self::LARANJA => '#FFA500',
         };
     }
+
+    public function borderLClass(): string
+    {
+        return match ($this) {
+            self::VERMELHA => 'border-l-red-500 dark:border-l-red-400',
+            self::AZUL => 'border-l-blue-500 dark:border-l-blue-400',
+            self::VERDE => 'border-l-green-500 dark:border-l-green-400',
+            self::AMARELA => 'border-l-yellow-400 dark:border-l-yellow-400',
+            self::LARANJA => 'border-l-orange-400 dark:border-l-orange-400',
+        };
+    }
 }

--- a/app/Enums/CorTroca.php
+++ b/app/Enums/CorTroca.php
@@ -42,4 +42,15 @@ enum CorTroca: string
             self::LARANJA => 'border-l-orange-400 dark:border-l-orange-400',
         };
     }
+
+    public function badgeClass(): string
+    {
+        return match ($this) {
+            self::VERMELHA => 'bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-300 border border-red-200 dark:border-red-800',
+            self::AZUL => 'bg-blue-100 text-blue-800 dark:bg-blue-950/40 dark:text-blue-300 border border-blue-200 dark:border-blue-800',
+            self::VERDE => 'bg-green-100 text-green-800 dark:bg-green-950/40 dark:text-green-300 border border-green-200 dark:border-green-800',
+            self::AMARELA => 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950/30 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-800',
+            self::LARANJA => 'bg-orange-100 text-orange-800 dark:bg-orange-950/40 dark:text-orange-300 border border-orange-200 dark:border-orange-800',
+        };
+    }
 }

--- a/app/Enums/TipoSituacao.php
+++ b/app/Enums/TipoSituacao.php
@@ -34,16 +34,86 @@ enum TipoSituacao: string
     public function badge(): array
     {
         return match ($this) {
-            self::NOVA => ['bg' => 'bg-slate-500', 'text' => 'text-slate-500', 'hover' => 'hover:bg-slate-600 hover:border-slate-600', 'border' => 'border-slate-500', 'light' => 'bg-slate-50 dark:bg-slate-900/20 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-700'],
-            self::SELECIONADA => ['bg' => 'bg-indigo-500', 'text' => 'text-indigo-500', 'hover' => 'hover:bg-indigo-600 hover:border-indigo-600', 'border' => 'border-indigo-500', 'light' => 'bg-indigo-50 dark:bg-indigo-900/20 text-indigo-700 dark:text-indigo-300 border-indigo-300 dark:border-indigo-700'],
-            self::CONTATO => ['bg' => 'bg-cyan-500', 'text' => 'text-cyan-500', 'hover' => 'hover:bg-cyan-600 hover:border-cyan-600', 'border' => 'border-cyan-500', 'light' => 'bg-cyan-50 dark:bg-cyan-900/20 text-cyan-700 dark:text-cyan-300 border-cyan-300 dark:border-cyan-700'],
-            self::AGUARDANDO => ['bg' => 'bg-purple-500', 'text' => 'text-purple-500', 'hover' => 'hover:bg-purple-600 hover:border-purple-600', 'border' => 'border-purple-500', 'light' => 'bg-purple-50 dark:bg-purple-900/20 text-purple-700 dark:text-purple-300 border-purple-300 dark:border-purple-700'],
-            self::VISITADA => ['bg' => 'bg-orange-500', 'text' => 'text-orange-500', 'hover' => 'hover:bg-orange-600 hover:border-orange-600', 'border' => 'border-orange-500', 'light' => 'bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-300 border-orange-300 dark:border-orange-700'],
-            self::ENVIADA => ['bg' => 'bg-blue-500', 'text' => 'text-blue-500', 'hover' => 'hover:bg-blue-600 hover:border-blue-600', 'border' => 'border-blue-500', 'light' => 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700'],
-            self::RECEBIDA => ['bg' => 'bg-teal-500', 'text' => 'text-teal-500', 'hover' => 'hover:bg-teal-600 hover:border-teal-600', 'border' => 'border-teal-500', 'light' => 'bg-teal-50 dark:bg-teal-900/20 text-teal-700 dark:text-teal-300 border-teal-300 dark:border-teal-700'],
-            self::PAGA => ['bg' => 'bg-emerald-500', 'text' => 'text-emerald-500', 'hover' => 'hover:bg-emerald-600 hover:border-emerald-600', 'border' => 'border-emerald-500', 'light' => 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-700'],
-            self::CANCELADA => ['bg' => 'bg-rose-500', 'text' => 'text-rose-500', 'hover' => 'hover:bg-rose-600 hover:border-rose-600', 'border' => 'border-rose-500', 'light' => 'bg-rose-50 dark:bg-rose-900/20 text-rose-700 dark:text-rose-300 border-rose-300 dark:border-rose-700'],
-            self::APROVADA => ['bg' => 'bg-amber-500', 'text' => 'text-amber-500', 'hover' => 'hover:bg-amber-600 hover:border-amber-600', 'border' => 'border-amber-500', 'light' => 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-700'],        
+            self::NOVA => [
+                'bg' => 'bg-slate-100 dark:bg-slate-900/40',
+                'text' => 'text-slate-800 dark:text-slate-300',
+                'hover' => 'hover:bg-slate-200 hover:border-slate-300',
+                'border' => 'border-slate-200',
+                'light' => 'bg-slate-100 text-slate-800 border-slate-200 dark:bg-slate-950/40 dark:text-slate-300 dark:border-slate-800',
+                'border-l' => 'border-l-slate-300 dark:border-l-slate-600'
+            ],
+            self::SELECIONADA => [
+                'bg' => 'bg-lime-100 dark:bg-lime-900/40',
+                'text' => 'text-lime-800 dark:text-lime-300',
+                'hover' => 'hover:bg-lime-200 hover:border-lime-300',
+                'border' => 'border-lime-200',
+                'light' => 'bg-lime-100 text-lime-800 border-lime-200 dark:bg-lime-950/40 dark:text-lime-300 dark:border-lime-800',
+                'border-l' => 'border-l-lime-500 dark:border-l-lime-400'
+            ],
+            self::CONTATO => [
+                'bg' => 'bg-sky-100 dark:bg-sky-900/40',
+                'text' => 'text-sky-800 dark:text-sky-300',
+                'hover' => 'hover:bg-sky-200 hover:border-sky-300',
+                'border' => 'border-sky-200',
+                'light' => 'bg-sky-100 text-sky-800 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-800',
+                'border-l' => 'border-l-sky-500 dark:border-l-sky-400'
+            ],
+            self::AGUARDANDO => [
+                'bg' => 'bg-amber-100 dark:bg-amber-900/40',
+                'text' => 'text-amber-800 dark:text-amber-300',
+                'hover' => 'hover:bg-amber-200 hover:border-amber-300',
+                'border' => 'border-amber-200',
+                'light' => 'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-950/30 dark:text-amber-300 dark:border-amber-800',
+                'border-l' => 'border-l-amber-500 dark:border-l-amber-400'
+            ],
+            self::VISITADA => [
+                'bg' => 'bg-purple-100 dark:bg-purple-900/40',
+                'text' => 'text-purple-800 dark:text-purple-300',
+                'hover' => 'hover:bg-purple-200 hover:border-purple-300',
+                'border' => 'border-purple-200',
+                'light' => 'bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-950/40 dark:text-purple-300 dark:border-purple-800',
+                'border-l' => 'border-l-purple-600 dark:border-l-purple-400'
+            ],
+            self::ENVIADA => [
+                'bg' => 'bg-cyan-50 dark:bg-cyan-900/30',
+                'text' => 'text-cyan-800 dark:text-cyan-300',
+                'hover' => 'hover:bg-cyan-100 hover:border-cyan-200',
+                'border' => 'border-cyan-200',
+                'light' => 'bg-cyan-50 text-cyan-800 border-cyan-200 dark:bg-cyan-950/30 dark:text-cyan-300 dark:border-cyan-800',
+                'border-l' => 'border-l-cyan-500 dark:border-l-cyan-400'
+            ],
+            self::RECEBIDA => [
+                'bg' => 'bg-green-100 dark:bg-green-900/40',
+                'text' => 'text-green-800 dark:text-green-300',
+                'hover' => 'hover:bg-green-200 hover:border-green-300',
+                'border' => 'border-green-200',
+                'light' => 'bg-green-100 text-green-800 border-green-200 dark:bg-green-950/40 dark:text-green-300 dark:border-green-800',
+                'border-l' => 'border-l-green-500 dark:border-l-green-400'
+            ],
+            self::PAGA => [
+                'bg' => 'bg-emerald-100 dark:bg-emerald-900/40',
+                'text' => 'text-emerald-800 dark:text-emerald-300',
+                'hover' => 'hover:bg-emerald-200 hover:border-emerald-300',
+                'border' => 'border-emerald-200',
+                'light' => 'bg-emerald-100 text-emerald-800 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800',
+                'border-l' => 'border-l-emerald-600 dark:border-l-emerald-400'
+            ],
+            self::CANCELADA => [
+                'bg' => 'bg-rose-100 dark:bg-rose-900/40',
+                'text' => 'text-rose-800 dark:text-rose-300',
+                'hover' => 'hover:bg-rose-200 hover:border-rose-300',
+                'border' => 'border-rose-200',
+                'light' => 'bg-rose-100 text-rose-800 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-800',
+                'border-l' => 'border-l-rose-500 dark:border-l-rose-400'
+            ],
+            self::APROVADA => [
+                'bg' => 'bg-teal-100 dark:bg-teal-900/40',
+                'text' => 'text-teal-800 dark:text-teal-300',
+                'hover' => 'hover:bg-teal-200 hover:border-teal-300',
+                'border' => 'border-teal-200',
+                'light' => 'bg-teal-100 text-teal-800 border-teal-200 dark:bg-teal-950/40 dark:text-teal-300 dark:border-teal-800',
+                'border-l' => 'border-l-teal-500 dark:border-l-teal-400'
+            ],
         };
     }
 

--- a/app/Http/Controllers/FichaSGMController.php
+++ b/app/Http/Controllers/FichaSGMController.php
@@ -140,6 +140,8 @@ class FichaSGMController extends Controller
 
         $sgmData = $sgmRequest->validated();
         unset($sgmData['med_foto']);
+        $fillable = (new FichaSGM)->getFillable();
+        $sgmData = array_intersect_key($sgmData, array_flip($fillable));
         $ficha->fichaSGM()->create($sgmData);
 
         if ($fichaRequest->filled('restricoes')) {
@@ -256,10 +258,12 @@ class FichaSGMController extends Controller
 
         $sgmData = $sgmRequest->validated();
         unset($sgmData['med_foto']);
+        $fillable = (new FichaSGM)->getFillable();
+        $sgmData = array_intersect_key($sgmData, array_flip($fillable));
         $sgmData['idt_ficha'] = $ficha->idt_ficha;
 
         if ($ficha->fichaSGM) {
-            $ficha->fichaSGM()->update($sgmData);
+            $ficha->fichaSGM->update($sgmData);
         } else {
             $ficha->fichaSGM()->create($sgmData);
         }

--- a/resources/views/ficha/formECC.blade.php
+++ b/resources/views/ficha/formECC.blade.php
@@ -112,7 +112,7 @@
                         @endphp
                         
                         @if($isCurrent)
-                            <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-bold text-white {{ $style['bg'] }} shadow-sm">
+                            <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-bold {{ $style['light'] }} shadow-sm">
                                 <x-heroicon-s-check class="w-4 h-4" />
                                 {{ $situacao->label() }}
                                 @if($situacao->mail()[0] === 'Sim')

--- a/resources/views/ficha/formSGM.blade.php
+++ b/resources/views/ficha/formSGM.blade.php
@@ -199,7 +199,7 @@
                         @endphp
                         
                         @if($isCurrent)
-                            <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-bold text-white {{ $style['bg'] }} shadow-sm">
+                            <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-bold {{ $style['light'] }} shadow-sm">
                                 <x-heroicon-s-check class="w-4 h-4" />
                                 {{ $situacao->label() }}
                                 @if($situacao->mail()[0] === 'Sim')

--- a/resources/views/ficha/formVEM.blade.php
+++ b/resources/views/ficha/formVEM.blade.php
@@ -149,7 +149,7 @@
                         @endphp
                         
                         @if($isCurrent)
-                            <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-bold text-white {{ $style['bg'] }} shadow-sm">
+                            <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-bold {{ $style['light'] }} shadow-sm">
                                 <x-heroicon-s-check class="w-4 h-4" />
                                 {{ $situacao->label() }}
                                 @if($situacao->mail()[0] === 'Sim')

--- a/resources/views/livewire/evento/partials/fichas.blade.php
+++ b/resources/views/livewire/evento/partials/fichas.blade.php
@@ -11,6 +11,7 @@ new class extends Component {
 
     public Evento $evento;
     public string $search = '';
+    public string $situacao = '';
 
     public function mount(Evento $evento): void
     {
@@ -19,6 +20,12 @@ new class extends Component {
 
     // Reseta a paginação quando a busca muda
     public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    // Reseta a paginação quando a situação muda
+    public function updatedSituacao(): void
     {
         $this->resetPage();
     }
@@ -71,6 +78,15 @@ new class extends Component {
     {
         $fichas = \App\Models\Ficha::with(['visitador', 'fichaVem', 'fichaEcc', 'fichaSGM'])
             ->where('idt_evento', $this->evento->idt_evento)
+            ->when($this->situacao, function ($query) {
+                $query->where('tip_situacao', $this->situacao);
+            })
+            ->when($this->search, function ($query) {
+                $query->where(function ($q) {
+                    $q->where('nom_candidato', 'like', '%' . $this->search . '%')
+                        ->orWhere('nom_apelido', 'like', '%' . $this->search . '%');
+                });
+            })
             ->get();
 
         $cabecalho = [
@@ -135,14 +151,31 @@ new class extends Component {
         return $response;
     }
 
+    /**
+     * Retorna a contagem de fichas agrupada por situação para o evento.
+     */
+    public function getQuantidadePorSituacao(): array
+    {
+        return \App\Models\Ficha::where('idt_evento', $this->evento->idt_evento)
+            ->select('tip_situacao', DB::raw('count(*) as total'))
+            ->groupBy('tip_situacao')
+            ->pluck('total', 'tip_situacao')
+            ->toArray();
+    }
+
     public function with(): array
     {
         return [
             'fichas' => \App\Models\Ficha::where('idt_evento', $this->evento->idt_evento)
                 ->with('evento') // necessário para rotasPorMovimento()
+                ->when($this->situacao, function ($query) {
+                    $query->where('tip_situacao', $this->situacao);
+                })
                 ->when($this->search, function ($query) {
-                    $query->where('nom_candidato', 'like', '%' . $this->search . '%')
-                        ->orWhere('nom_apelido', 'like', '%' . $this->search . '%');
+                    $query->where(function ($q) {
+                        $q->where('nom_candidato', 'like', '%' . $this->search . '%')
+                            ->orWhere('nom_apelido', 'like', '%' . $this->search . '%');
+                    });
                 })
                 ->paginate(10),
         ];
@@ -154,6 +187,7 @@ new class extends Component {
         <div>
             <div class="flex items-center gap-3">
                 <flux:heading size="lg">Fichas de Inscrição</flux:heading>
+                <flux:badge size="sm" color="zinc" inset="top bottom" title="Total filtrado">{{ $fichas->total() }}</flux:badge>
                 <flux:button wire:click="exportar" icon="arrow-down-tray" variant="outline" size="sm" title="Exportar CSV">
                     Exportar
                 </flux:button>
@@ -161,9 +195,24 @@ new class extends Component {
             <flux:subheading>Analise e aprove os candidatos para este evento.</flux:subheading>
         </div>
 
-        <div class="w-full md:w-auto">
-            <flux:input wire:model.live.debounce.300ms="search" icon="magnifying-glass" placeholder="Buscar ficha..."
-                class="w-full md:max-w-xs" />
+        @php
+            $quantidades = $this->getQuantidadePorSituacao();
+            $totalFichas = array_sum($quantidades);
+        @endphp
+
+        <div class="flex flex-col sm:flex-row gap-2 w-full md:w-auto">
+            <flux:select wire:model.live="situacao" icon="funnel" placeholder="Todas as situações" class="w-full sm:w-64">
+                <option value="">Todas as situações ({{ $totalFichas }})</option>
+                @foreach (\App\Enums\TipoSituacao::cases() as $sit)
+                    @php
+                        $qtd = $quantidades[$sit->value] ?? 0;
+                    @endphp
+                    <option value="{{ $sit->value }}">{{ $sit->label() }} ({{ $qtd }})</option>
+                @endforeach
+            </flux:select>
+
+            <flux:input wire:model.live.debounce.300ms="search" icon="magnifying-glass" 
+                placeholder="Buscar candidato(a)..." class="w-full sm:w-64" />
         </div>
     </div>
 
@@ -199,16 +248,15 @@ new class extends Component {
                 </flux:table.cell>
 
                 <flux:table.cell>
-                    <flux:select
+                    <select
                         wire:change="atualizarSituacao({{ $ficha->idt_ficha }}, $event.target.value)"
-                        size="sm"
-                        class="w-40">
+                        class="w-40 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 px-2.5 py-1.5 text-xs font-semibold shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 border-l-[5px] {{ $ficha->tip_situacao?->badge()['border-l'] ?? 'border-l-zinc-200 dark:border-l-zinc-700' }}">
                         @foreach (\App\Enums\TipoSituacao::cases() as $situacao)
-                            <option value="{{ $situacao->value }}" @selected($ficha->tip_situacao === $situacao)>
+                            <option value="{{ $situacao->value }}" @selected($ficha->tip_situacao === $situacao) class="text-zinc-800 bg-white dark:bg-zinc-900 dark:text-zinc-200">
                                 {{ $situacao->label() }}
                             </option>
                         @endforeach
-                    </flux:select>
+                    </select>
                 </flux:table.cell>
 
                 <flux:table.cell align="end">

--- a/resources/views/livewire/evento/partials/fichas.blade.php
+++ b/resources/views/livewire/evento/partials/fichas.blade.php
@@ -12,6 +12,9 @@ new class extends Component {
     public Evento $evento;
     public string $search = '';
     public string $situacao = '';
+    public string $generoFiltro = '';
+    public bool $vinculoFiltroParoquiano = false;
+    public bool $vinculoFiltroRegiao = false;
 
     public function mount(Evento $evento): void
     {
@@ -26,6 +29,24 @@ new class extends Component {
 
     // Reseta a paginação quando a situação muda
     public function updatedSituacao(): void
+    {
+        $this->resetPage();
+    }
+
+    // Reseta a paginação quando o gênero muda
+    public function updatedGeneroFiltro(): void
+    {
+        $this->resetPage();
+    }
+
+    // Reseta a paginação quando o filtro de paroquiano muda
+    public function updatedVinculoFiltroParoquiano(): void
+    {
+        $this->resetPage();
+    }
+
+    // Reseta a paginação quando o filtro de região muda
+    public function updatedVinculoFiltroRegiao(): void
     {
         $this->resetPage();
     }
@@ -80,6 +101,39 @@ new class extends Component {
             ->where('idt_evento', $this->evento->idt_evento)
             ->when($this->situacao, function ($query) {
                 $query->where('tip_situacao', $this->situacao);
+            })
+            ->when($this->generoFiltro, function ($query) {
+                $query->where('tip_genero', $this->generoFiltro);
+            })
+            ->when($this->vinculoFiltroParoquiano, function ($query) {
+                $movimentoId = (int) $this->evento->idt_movimento;
+                $query->where(function ($q) use ($movimentoId) {
+                    if ($movimentoId === \App\Models\TipoMovimento::VEM) {
+                        $q->whereHas('fichaVem', function ($q2) {
+                            $q2->where('nom_paroquia', 'like', '%PNSL%')
+                               ->orWhere('nom_paroquia', 'like', '%Nossa Senhora do Lago%');
+                        });
+                    } elseif ($movimentoId === \App\Models\TipoMovimento::ECC) {
+                        $q->whereHas('fichaEcc', function ($q2) {
+                            $q2->where('nom_paroquia', 'like', '%PNSL%')
+                               ->orWhere('nom_paroquia', 'like', '%Nossa Senhora do Lago%');
+                        });
+                    } elseif ($movimentoId === \App\Models\TipoMovimento::SGM) {
+                        $q->whereHas('fichaSGM', function ($q2) {
+                            $q2->where('nom_paroquia', 'like', '%PNSL%')
+                               ->orWhere('nom_paroquia', 'like', '%Nossa Senhora do Lago%');
+                        });
+                    }
+                });
+            })
+            ->when($this->vinculoFiltroRegiao, function ($query) {
+                $query->where(function ($q) {
+                    $q->where('des_endereco', 'like', '%Lago Norte%')
+                      ->orWhere('des_endereco', 'like', '%SHIN%')
+                      ->orWhere('des_endereco', 'like', '%Setor de Mansões%')
+                      ->orWhere('des_endereco', 'like', '%Taquari%')
+                      ->orWhere('des_endereco', 'like', '%Varjão%');
+                });
             })
             ->when($this->search, function ($query) {
                 $query->where(function ($q) {
@@ -167,9 +221,42 @@ new class extends Component {
     {
         return [
             'fichas' => \App\Models\Ficha::where('idt_evento', $this->evento->idt_evento)
-                ->with('evento') // necessário para rotasPorMovimento()
+                ->with(['evento', 'fichaVem', 'fichaEcc', 'fichaSGM']) // necessário para rotasPorMovimento() e vínculos
                 ->when($this->situacao, function ($query) {
                     $query->where('tip_situacao', $this->situacao);
+                })
+                ->when($this->generoFiltro, function ($query) {
+                    $query->where('tip_genero', $this->generoFiltro);
+                })
+                ->when($this->vinculoFiltroParoquiano, function ($query) {
+                    $movimentoId = (int) $this->evento->idt_movimento;
+                    $query->where(function ($q) use ($movimentoId) {
+                        if ($movimentoId === \App\Models\TipoMovimento::VEM) {
+                            $q->whereHas('fichaVem', function ($q2) {
+                                $q2->where('nom_paroquia', 'like', '%PNSL%')
+                                   ->orWhere('nom_paroquia', 'like', '%Nossa Senhora do Lago%');
+                            });
+                        } elseif ($movimentoId === \App\Models\TipoMovimento::ECC) {
+                            $q->whereHas('fichaEcc', function ($q2) {
+                                $q2->where('nom_paroquia', 'like', '%PNSL%')
+                                   ->orWhere('nom_paroquia', 'like', '%Nossa Senhora do Lago%');
+                            });
+                        } elseif ($movimentoId === \App\Models\TipoMovimento::SGM) {
+                            $q->whereHas('fichaSGM', function ($q2) {
+                                $q2->where('nom_paroquia', 'like', '%PNSL%')
+                                   ->orWhere('nom_paroquia', 'like', '%Nossa Senhora do Lago%');
+                            });
+                        }
+                    });
+                })
+                ->when($this->vinculoFiltroRegiao, function ($query) {
+                    $query->where(function ($q) {
+                        $q->where('des_endereco', 'like', '%Lago Norte%')
+                          ->orWhere('des_endereco', 'like', '%SHIN%')
+                          ->orWhere('des_endereco', 'like', '%Setor de Mansões%')
+                          ->orWhere('des_endereco', 'like', '%Taquari%')
+                          ->orWhere('des_endereco', 'like', '%Varjão%');
+                    });
                 })
                 ->when($this->search, function ($query) {
                     $query->where(function ($q) {
@@ -200,8 +287,8 @@ new class extends Component {
             $totalFichas = array_sum($quantidades);
         @endphp
 
-        <div class="flex flex-col sm:flex-row gap-2 w-full md:w-auto">
-            <flux:select wire:model.live="situacao" icon="funnel" placeholder="Todas as situações" class="w-full sm:w-64">
+        <div class="flex flex-col sm:flex-row gap-2 w-full md:w-auto items-end">
+            <flux:select wire:model.live="situacao" icon="funnel" placeholder="Todas as situações" class="w-full sm:w-44">
                 <option value="">Todas as situações ({{ $totalFichas }})</option>
                 @foreach (\App\Enums\TipoSituacao::cases() as $sit)
                     @php
@@ -211,8 +298,30 @@ new class extends Component {
                 @endforeach
             </flux:select>
 
+            <flux:select wire:model.live="generoFiltro" icon="funnel" placeholder="Todos os sexos" class="w-full sm:w-36">
+                <option value="">Todos os sexos</option>
+                <option value="M">Masculino</option>
+                <option value="F">Feminino</option>
+            </flux:select>
+
+            <flux:dropdown>
+                <flux:button icon="link" variant="outline" class="w-full sm:w-44 justify-between">
+                    <span>Vínculos</span>
+                    @php
+                        $count = ($vinculoFiltroParoquiano ? 1 : 0) + ($vinculoFiltroRegiao ? 1 : 0);
+                    @endphp
+                    @if ($count > 0)
+                        <flux:badge size="sm" color="indigo" class="ml-2 shrink-0">{{ $count }}</flux:badge>
+                    @endif
+                </flux:button>
+                <flux:menu class="p-3 space-y-3 min-w-[14rem]">
+                    <flux:checkbox wire:model.live="vinculoFiltroParoquiano" label="Paroquialidade" />
+                    <flux:checkbox wire:model.live="vinculoFiltroRegiao" label="Região" />
+                </flux:menu>
+            </flux:dropdown>
+
             <flux:input wire:model.live.debounce.300ms="search" icon="magnifying-glass" 
-                placeholder="Buscar candidato(a)..." class="w-full sm:w-64" />
+                placeholder="Buscar..." class="w-full sm:w-44" />
         </div>
     </div>
 
@@ -220,15 +329,43 @@ new class extends Component {
         <flux:table.columns>
             <flux:table.column>Candidato</flux:table.column>
             <flux:table.column>Data Nasc</flux:table.column>
+            <flux:table.column>Endereço</flux:table.column>
             <flux:table.column>Situação</flux:table.column>
+            <flux:table.column>Vínculo</flux:table.column>
             <flux:table.column align="end">Ações</flux:table.column>
         </flux:table.columns>
 
         <flux:table.rows>
             @forelse ($fichas as $ficha)
+                @php
+                    $movimentoId = (int) $ficha->evento->idt_movimento;
+                    $nomParoquia = match ($movimentoId) {
+                        \App\Models\TipoMovimento::VEM => $ficha->fichaVem?->nom_paroquia,
+                        \App\Models\TipoMovimento::ECC => $ficha->fichaEcc?->nom_paroquia,
+                        \App\Models\TipoMovimento::SGM => $ficha->fichaSGM?->nom_paroquia,
+                        default => '',
+                    } ?? '';
+                    $isParoquiano = preg_match('/PNSL|Nossa Senhora do Lago/i', (string) $nomParoquia);
+                    $isRegiao = preg_match('/Lago Norte|SHIN|Setor de Mans.es|Taquari|Varj.o/iu', (string) $ficha->des_endereco);
+                @endphp
             <flux:table.row :key="'ficha-'.$ficha->idt_ficha">
                 <flux:table.cell>
-                    <div class="font-medium text-zinc-900 dark:text-white">{{ $ficha->nom_candidato }}</div>
+                    <div class="font-medium text-zinc-900 dark:text-white flex items-center gap-1.5">
+                        <span>{{ $ficha->nom_candidato }}</span>
+                        @if ($ficha->tip_genero === \App\Enums\Genero::MASCULINO)
+                            <svg class="w-2.5 h-2.5 text-blue-500 dark:text-blue-400 shrink-0 cursor-default" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" title="Masculino">
+                                <circle cx="10" cy="14" r="6" />
+                                <path d="M16 8L21 3" />
+                                <path d="M15 3H21V9" />
+                            </svg>
+                        @elseif ($ficha->tip_genero === \App\Enums\Genero::FEMININO)
+                            <svg class="w-2.5 h-2.5 text-pink-500 dark:text-pink-400 shrink-0 cursor-default" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" title="Feminino">
+                                <circle cx="12" cy="9" r="6" />
+                                <path d="M12 15V22" />
+                                <path d="M8 18H16" />
+                            </svg>
+                        @endif
+                    </div>
                     <div class="text-xs text-zinc-500">{{ $ficha->nom_apelido }}</div>
                     @if(!$ficha->num_cpf_candidato)
                         <div class="flex items-center gap-1 mt-1">
@@ -247,6 +384,10 @@ new class extends Component {
                     </div>
                 </flux:table.cell>
 
+                <flux:table.cell class="max-w-xs truncate" title="{{ $ficha->des_endereco }}">
+                    <flux:text size="sm" class="truncate block">{{ $ficha->des_endereco ?: '—' }}</flux:text>
+                </flux:table.cell>
+
                 <flux:table.cell>
                     <select
                         wire:change="atualizarSituacao({{ $ficha->idt_ficha }}, $event.target.value)"
@@ -257,6 +398,29 @@ new class extends Component {
                             </option>
                         @endforeach
                     </select>
+                </flux:table.cell>
+
+                <flux:table.cell>
+                    <div class="space-y-1 text-xs">
+                        <div class="flex items-center gap-1" title="Paróquia: {{ $nomParoquia ?: 'Não informada' }}">
+                            @if ($isParoquiano)
+                                <span class="text-green-600 dark:text-green-400 font-medium">Paroquiano</span>
+                                <flux:icon.check class="size-3 text-green-500 shrink-0" />
+                            @else
+                                <span class="text-red-600 dark:text-red-400 font-medium">Não Paroquiano</span>
+                                <flux:icon.x-mark class="size-3 text-red-500 shrink-0" />
+                            @endif
+                        </div>
+                        <div class="flex items-center gap-1">
+                            @if ($isRegiao)
+                                <span class="text-green-600 dark:text-green-400 font-medium">Região</span>
+                                <flux:icon.check class="size-3 text-green-500 shrink-0" />
+                            @else
+                                <span class="text-red-600 dark:text-red-400 font-medium">Região</span>
+                                <flux:icon.x-mark class="size-3 text-red-500 shrink-0" />
+                            @endif
+                        </div>
+                    </div>
                 </flux:table.cell>
 
                 <flux:table.cell align="end">
@@ -314,7 +478,7 @@ new class extends Component {
             </flux:table.row>
             @empty
             <flux:table.row>
-                <flux:table.cell colspan="4" class="text-center py-12">
+                <flux:table.cell colspan="6" class="text-center py-12">
                     <div class="flex flex-col items-center">
                         <x-heroicon-o-document-magnifying-glass class="w-12 h-12 text-zinc-300 mb-2" />
                         <flux:text>Nenhuma ficha encontrada para este critério.</flux:text>

--- a/resources/views/livewire/evento/partials/participantes.blade.php
+++ b/resources/views/livewire/evento/partials/participantes.blade.php
@@ -11,6 +11,7 @@ new class extends Component {
 
     public Evento $evento;
     public string $search = '';
+    public string $corTroca = '';
 
     public function mount(Evento $evento): void
     {
@@ -18,6 +19,11 @@ new class extends Component {
     }
 
     public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedCorTroca(): void
     {
         $this->resetPage();
     }
@@ -49,6 +55,15 @@ new class extends Component {
             ->select('participante.*')
             ->join('pessoa', 'participante.idt_pessoa', '=', 'pessoa.idt_pessoa')
             ->where('participante.idt_evento', $eventoId)
+            ->when($this->corTroca, function ($query) {
+                $query->where('participante.tip_cor_troca', $this->corTroca);
+            })
+            ->when($this->search, function ($query) {
+                $query->where(function ($q) {
+                    $q->where('pessoa.nom_pessoa', 'like', '%' . $this->search . '%')
+                        ->orWhere('pessoa.nom_apelido', 'like', '%' . $this->search . '%');
+                });
+            })
             ->with([
                 'pessoa.restricoes',
                 'pessoa.fichas' => function ($query) use ($eventoId) {
@@ -147,6 +162,18 @@ new class extends Component {
         return $response;
     }
 
+    /**
+     * Retorna a contagem de participantes agrupada por cor da troca.
+     */
+    public function getQuantidadePorCor(): array
+    {
+        return \App\Models\Participante::where('idt_evento', $this->evento->idt_evento)
+            ->select('tip_cor_troca', \DB::raw('count(*) as total'))
+            ->groupBy('tip_cor_troca')
+            ->pluck('total', 'tip_cor_troca')
+            ->toArray();
+    }
+
     public function with(): array
     {
         return [
@@ -162,6 +189,9 @@ new class extends Component {
                             ->with(['fichaVem', 'fichaSGM']);
                     }
                 ])
+                ->when($this->corTroca, function ($query) {
+                    $query->where('participante.tip_cor_troca', $this->corTroca);
+                })
                 ->when($this->search, function ($query) {
                     $query->where(function ($q) {
                         $q->where('pessoa.nom_pessoa', 'like', '%' . $this->search . '%')
@@ -179,6 +209,7 @@ new class extends Component {
         <div>
             <div class="flex items-center gap-3">
                 <flux:heading size="lg">Participantes Confirmados</flux:heading>
+                <flux:badge size="sm" color="zinc" inset="top bottom" title="Total filtrado">{{ $participantes->total() }}</flux:badge>
                 <flux:button wire:click="exportar" icon="arrow-down-tray" variant="outline" size="sm" title="Exportar CSV">
                     Exportar
                 </flux:button>
@@ -186,18 +217,35 @@ new class extends Component {
             <flux:subheading>Gerencie as cores das trocas e informações básicas.</flux:subheading>
         </div>
 
-        <flux:input
-            wire:model.live.debounce.300ms="search"
-            icon="magnifying-glass"
-            placeholder="Nome ou apelido..."
-            class="w-full md:max-w-xs"
-        />
+        @php
+            $quantidades = $this->getQuantidadePorCor();
+            $totalParticipantes = \App\Models\Participante::where('idt_evento', $this->evento->idt_evento)->count();
+        @endphp
+
+        <div class="flex flex-col sm:flex-row gap-2 w-full md:w-auto">
+            <flux:select wire:model.live="corTroca" icon="funnel" placeholder="Todas as cores" class="w-full sm:w-64">
+                <option value="">Todas as cores ({{ $totalParticipantes }})</option>
+                @foreach (CorTroca::cases() as $cor)
+                    @php
+                        $qtd = $quantidades[strtolower($cor->value)] ?? $quantidades[ucfirst($cor->value)] ?? $quantidades[$cor->value] ?? 0;
+                    @endphp
+                    <option value="{{ $cor->value }}">{{ $cor->label() }} ({{ $qtd }})</option>
+                @endforeach
+            </flux:select>
+
+            <flux:input
+                wire:model.live.debounce.300ms="search"
+                icon="magnifying-glass"
+                placeholder="Nome ou apelido..."
+                class="w-full sm:w-64"
+            />
+        </div>
     </div>
 
     <flux:table>
         <flux:table.columns>
             <flux:table.column>Nome</flux:table.column>
-            <flux:table.column>Cor da Troca</flux:table.column>
+            <flux:table.column>Cor do Grupo</flux:table.column>
             <flux:table.column>Camiseta</flux:table.column>
             <flux:table.column>Responsável</flux:table.column>
             <flux:table.column align="end">Ações</flux:table.column>
@@ -221,16 +269,15 @@ new class extends Component {
 
                     {{-- Cor da Troca --}}
                     <flux:table.cell>
-                        <flux:select
+                        <select
                             wire:change="atualizarTroca({{ $p->idt_participante }}, $event.target.value)"
-                            size="sm"
-                            class="w-32">
+                            class="w-32 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 px-2.5 py-1.5 text-xs font-semibold shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 border-l-[5px] {{ \App\Enums\CorTroca::tryFrom(strtolower($p->tip_cor_troca))?->borderLClass() ?? 'border-l-zinc-200 dark:border-l-zinc-700' }}">
                             @foreach (CorTroca::cases() as $cor)
-                                <option value="{{ $cor->value }}" @selected(strtolower($p->tip_cor_troca) === $cor->value)>
+                                <option value="{{ $cor->value }}" @selected(strtolower($p->tip_cor_troca) === $cor->value) class="text-zinc-800 bg-white dark:bg-zinc-900 dark:text-zinc-200">
                                     {{ $cor->label() }}
                                 </option>
                             @endforeach
-                        </flux:select>
+                        </select>
                     </flux:table.cell>
 
                     {{-- Camiseta --}}

--- a/resources/views/livewire/evento/partials/presenca.blade.php
+++ b/resources/views/livewire/evento/partials/presenca.blade.php
@@ -16,7 +16,8 @@ use Livewire\Attributes\Computed;
 new class extends Component {
     public Evento $evento;
     public string $search     = '';
-    public string $filtroTipo = 'todos';
+    public string $equipeFiltroId = '';
+    public string $grupoFiltro = '';
 
     public function mount(Evento $evento): void
     {
@@ -44,9 +45,11 @@ new class extends Component {
         $search = $this->search;
         $items  = [];
 
-        if (in_array($this->filtroTipo, ['todos', 'participantes'])) {
+        // 1. Carregar participantes se não houver filtro de equipe
+        if (!$this->equipeFiltroId) {
             $participantes = Participante::where('idt_evento', $this->evento->idt_evento)
                 ->with('pessoa')
+                ->when($this->grupoFiltro, fn($q) => $q->where('tip_cor_troca', $this->grupoFiltro))
                 ->when($search, fn($q) => $q->whereHas('pessoa', fn($q2) =>
                     $q2->where('nom_pessoa', 'like', "%{$search}%")
                        ->orWhere('nom_apelido', 'like', "%{$search}%")
@@ -54,23 +57,37 @@ new class extends Component {
                 ->get();
 
             foreach ($participantes as $p) {
+                $corEnum = $p->tip_cor_troca ? \App\Enums\CorTroca::tryFrom(strtolower($p->tip_cor_troca)) : null;
+                $grupo_cor_class = match ($corEnum) {
+                    \App\Enums\CorTroca::VERMELHA => 'text-red-600 dark:text-red-400 font-semibold',
+                    \App\Enums\CorTroca::AZUL => 'text-blue-600 dark:text-blue-400 font-semibold',
+                    \App\Enums\CorTroca::VERDE => 'text-green-600 dark:text-green-400 font-semibold',
+                    \App\Enums\CorTroca::AMARELA => 'text-amber-600 dark:text-amber-400 font-semibold',
+                    \App\Enums\CorTroca::LARANJA => 'text-orange-600 dark:text-orange-400 font-semibold',
+                    default => 'text-zinc-500 dark:text-zinc-400 font-medium',
+                };
+
                 $items[] = [
-                    'id'           => $p->idt_participante,
-                    'tipo'         => 'participante',
-                    'nome'         => $p->pessoa->nom_pessoa ?? '',
-                    'apelido'      => $p->pessoa->nom_apelido ?? '',
-                    'telefone'     => $p->pessoa->tel_pessoa ?? '',
-                    'nascimento'   => $p->pessoa->dat_nascimento,
-                    'ind_presente' => (bool) $p->ind_presente,
-                    'grupo'        => null,
+                    'id'              => $p->idt_participante,
+                    'tipo'            => 'participante',
+                    'nome'            => $p->pessoa->nom_pessoa ?? '',
+                    'apelido'         => $p->pessoa->nom_apelido ?? '',
+                    'telefone'        => $p->pessoa->tel_pessoa ?? '',
+                    'nascimento'      => $p->pessoa->dat_nascimento,
+                    'ind_presente'    => (bool) $p->ind_presente,
+                    'grupo'           => $p->tip_cor_troca ? ucfirst($p->tip_cor_troca) : 'Geral',
+                    'grupo_cor_class' => $grupo_cor_class,
+                    'ind_coordenador' => false,
                 ];
             }
         }
 
-        if (in_array($this->filtroTipo, ['todos', 'trabalhadores'])) {
+        // 2. Carregar trabalhadores se não houver filtro de grupo
+        if (!$this->grupoFiltro) {
             $trabalhadores = Trabalhador::where('idt_evento', $this->evento->idt_evento)
                 ->whereHas('pessoa')
                 ->with(['pessoa', 'equipe'])
+                ->when($this->equipeFiltroId, fn($q) => $q->where('idt_equipe', $this->equipeFiltroId))
                 ->when($search, fn($q) => $q->whereHas('pessoa', fn($q2) =>
                     $q2->where('nom_pessoa', 'like', "%{$search}%")
                        ->orWhere('nom_apelido', 'like', "%{$search}%")
@@ -79,14 +96,16 @@ new class extends Component {
 
             foreach ($trabalhadores as $t) {
                 $items[] = [
-                    'id'           => $t->idt_trabalhador,
-                    'tipo'         => 'trabalhador',
-                    'nome'         => $t->pessoa->nom_pessoa ?? '',
-                    'apelido'      => $t->pessoa->nom_apelido ?? '',
-                    'telefone'     => $t->pessoa->tel_pessoa ?? '',
-                    'nascimento'   => $t->pessoa->dat_nascimento,
-                    'ind_presente' => (bool) $t->ind_presente,
-                    'grupo'        => $t->equipe?->des_grupo,
+                    'id'              => $t->idt_trabalhador,
+                    'tipo'            => 'trabalhador',
+                    'nome'            => $t->pessoa->nom_pessoa ?? '',
+                    'apelido'         => $t->pessoa->nom_apelido ?? '',
+                    'telefone'        => $t->pessoa->tel_pessoa ?? '',
+                    'nascimento'      => $t->pessoa->dat_nascimento,
+                    'ind_presente'    => (bool) $t->ind_presente,
+                    'grupo'           => $t->equipe ? $t->equipe->des_grupo : 'Sem Equipe',
+                    'grupo_cor_class' => 'text-zinc-500 dark:text-zinc-400 font-medium',
+                    'ind_coordenador' => (bool) $t->ind_coordenador,
                 ];
             }
         }
@@ -94,12 +113,19 @@ new class extends Component {
         usort($items, fn($a, $b) => strcmp($a['nome'], $b['nome']));
         return $items;
     }
+
+    public function with(): array
+    {
+        return [
+            'equipes' => \App\Models\TipoEquipe::where('idt_movimento', $this->evento->movimento->idt_movimento)->get(),
+        ];
+    }
 }; ?>
 
 <div class="space-y-6">
 
     {{-- Cabeçalho --}}
-    <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+    <div class="flex flex-col md:flex-row justify-between items-start md:items-end gap-4">
         <div>
             <flux:heading size="lg">Controle de Presença</flux:heading>
             @php
@@ -110,18 +136,29 @@ new class extends Component {
             <flux:subheading>{{ $presentes }} presente(s) de {{ $total }} pessoa(s)</flux:subheading>
         </div>
 
-        <div class="flex flex-col sm:flex-row gap-2 w-full md:w-auto">
-            <flux:select wire:model.live="filtroTipo" size="sm" class="w-full sm:w-44">
-                <option value="todos">Todos</option>
-                <option value="participantes">Participantes</option>
-                <option value="trabalhadores">Trabalhadores</option>
+        <div class="flex flex-col sm:flex-row gap-2 w-full md:w-auto items-end">
+            <flux:select label="Equipe" wire:model.live="equipeFiltroId" placeholder="Todas" class="w-full sm:w-48">
+                <option value="">Todas as equipes</option>
+                @foreach ($equipes as $eq)
+                    <option value="{{ $eq->idt_equipe }}">{{ $eq->des_grupo }}</option>
+                @endforeach
+            </flux:select>
+
+            <flux:select label="Grupo" wire:model.live="grupoFiltro" placeholder="Todos" class="w-full sm:w-48">
+                <option value="">Todos os grupos</option>
+                <option value="vermelha">Vermelha</option>
+                <option value="azul">Azul</option>
+                <option value="verde">Verde</option>
+                <option value="amarela">Amarela</option>
+                <option value="laranja">Laranja</option>
             </flux:select>
 
             <flux:input
+                label="Busca"
                 wire:model.live.debounce.300ms="search"
                 icon="magnifying-glass"
                 placeholder="Nome ou apelido..."
-                class="w-full sm:w-64"
+                class="w-full sm:w-56"
             />
         </div>
     </div>
@@ -159,12 +196,17 @@ new class extends Component {
                         <div class="flex items-center gap-3">
                             <flux:avatar :initials="mb_substr($item['nome'] ?? '?', 0, 2)" size="sm" />
                             <div>
-                                <div class="font-medium text-zinc-900 dark:text-white">{{ $item['nome'] }}</div>
+                                <div class="font-medium text-zinc-900 dark:text-white flex items-center gap-2">
+                                    <span>{{ $item['nome'] }}</span>
+                                    @if ($item['tipo'] === 'trabalhador' && $item['ind_coordenador'])
+                                        <flux:icon.star variant="solid" class="size-4 text-yellow-500 shrink-0 cursor-default" title="Coordenador da Equipe" />
+                                    @endif
+                                </div>
                                 @if($item['apelido'])
                                     <div class="text-xs text-zinc-500">{{ $item['apelido'] }}</div>
                                 @endif
                                 @if($item['grupo'])
-                                    <div class="text-xs text-blue-500">{{ $item['grupo'] }}</div>
+                                    <div class="text-xs {{ $item['grupo_cor_class'] }} mt-0.5 leading-none">{{ $item['grupo'] }}</div>
                                 @endif
                             </div>
                         </div>

--- a/resources/views/livewire/evento/partials/restricoes.blade.php
+++ b/resources/views/livewire/evento/partials/restricoes.blade.php
@@ -8,6 +8,8 @@ use Livewire\Attributes\Computed;
 
 new class extends Component {
     public Evento $evento;
+    public string $search = '';
+    public string $tipo = '';
 
     public function mount(Evento $evento): void
     {
@@ -21,44 +23,66 @@ new class extends Component {
         $restricoes = [];
 
         // 1. Participantes Aprovados com Restrição
-        $participantes = Participante::where('idt_evento', $eventoSelecionadoId)
-            ->whereHas('pessoa.restricoes')
-            ->with(['pessoa.restricoes'])
-            ->get();
+        if ($this->tipo === '' || $this->tipo === 'Participante') {
+            $participantes = Participante::where('idt_evento', $eventoSelecionadoId)
+                ->whereHas('pessoa', function ($query) {
+                    $query->whereHas('restricoes')
+                        ->when($this->search, function ($q) {
+                            $q->where(function ($sub) {
+                                $sub->where('nom_pessoa', 'like', '%' . $this->search . '%')
+                                    ->orWhere('nom_apelido', 'like', '%' . $this->search . '%');
+                            });
+                        });
+                })
+                ->with(['pessoa.restricoes'])
+                ->get();
 
-        foreach ($participantes as $part) {
-            foreach ($part->pessoa->restricoes as $restricao) {
-                $txt_complemento = $restricao->pivot?->txt_complemento;
-                $restricoes[] = (object) [
-                    'nome' => $part->pessoa->nom_pessoa . ($part->pessoa->nom_apelido ? " ({$part->pessoa->nom_apelido})" : ""),
-                    'tipo_cadastro' => 'Participante',
-                    'troca' => $part->tip_cor_troca ? ucfirst($part->tip_cor_troca) : 'Geral',
-                    'equipe' => '-',
-                    'tipo_restricao' => $restricao->getTipo(),
-                    'tipo_restricao_cor' => $restricao->getCor(),
-                    'desc_restricao' => $restricao->des_restricao . ($txt_complemento ? " — " . $txt_complemento : ""),
-                ];
+            foreach ($participantes as $part) {
+                foreach ($part->pessoa->restricoes as $restricao) {
+                    $txt_complemento = $restricao->pivot?->txt_complemento;
+                    $restricoes[] = (object) [
+                        'nome' => $part->pessoa->nom_pessoa . ($part->pessoa->nom_apelido ? " ({$part->pessoa->nom_apelido})" : ""),
+                        'tipo_cadastro' => 'Participante',
+                        'troca' => $part->tip_cor_troca ? ucfirst($part->tip_cor_troca) : 'Geral',
+                        'troca_cor' => $part->tip_cor_troca ? (\App\Enums\CorTroca::tryFrom(strtolower($part->tip_cor_troca))?->badgeClass() ?? '') : '',
+                        'equipe' => '-',
+                        'tipo_restricao' => $restricao->getTipo(),
+                        'tipo_restricao_cor' => $restricao->getCor(),
+                        'desc_restricao' => $restricao->des_restricao . ($txt_complemento ? " — " . $txt_complemento : ""),
+                    ];
+                }
             }
         }
 
         // 2. Trabalhadores Aprovados com Restrição
-        $trabalhadores = Trabalhador::where('idt_evento', $eventoSelecionadoId)
-            ->whereHas('pessoa.restricoes')
-            ->with(['pessoa.restricoes', 'equipe'])
-            ->get();
+        if ($this->tipo === '' || $this->tipo === 'Trabalhador') {
+            $trabalhadores = Trabalhador::where('idt_evento', $eventoSelecionadoId)
+                ->whereHas('pessoa', function ($query) {
+                    $query->whereHas('restricoes')
+                        ->when($this->search, function ($q) {
+                            $q->where(function ($sub) {
+                                $sub->where('nom_pessoa', 'like', '%' . $this->search . '%')
+                                    ->orWhere('nom_apelido', 'like', '%' . $this->search . '%');
+                            });
+                        });
+                })
+                ->with(['pessoa.restricoes', 'equipe'])
+                ->get();
 
-        foreach ($trabalhadores as $trab) {
-            foreach ($trab->pessoa->restricoes as $restricao) {
-                $txt_complemento = $restricao->pivot?->txt_complemento;
-                $restricoes[] = (object) [
-                    'nome' => $trab->pessoa->nom_pessoa . ($trab->pessoa->nom_apelido ? " ({$trab->pessoa->nom_apelido})" : ""),
-                    'tipo_cadastro' => 'Trabalhador',
-                    'troca' => '-',
-                    'equipe' => $trab->equipe ? $trab->equipe->des_grupo : 'Sem Equipe',
-                    'tipo_restricao' => $restricao->getTipo(),
-                    'tipo_restricao_cor' => $restricao->getCor(),
-                    'desc_restricao' => $restricao->des_restricao . ($txt_complemento ? " — " . $txt_complemento : ""),
-                ];
+            foreach ($trabalhadores as $trab) {
+                foreach ($trab->pessoa->restricoes as $restricao) {
+                    $txt_complemento = $restricao->pivot?->txt_complemento;
+                    $restricoes[] = (object) [
+                        'nome' => $trab->pessoa->nom_pessoa . ($trab->pessoa->nom_apelido ? " ({$trab->pessoa->nom_apelido})" : ""),
+                        'tipo_cadastro' => 'Trabalhador',
+                        'troca' => '-',
+                        'troca_cor' => '',
+                        'equipe' => $trab->equipe ? $trab->equipe->des_grupo : 'Sem Equipe',
+                        'tipo_restricao' => $restricao->getTipo(),
+                        'tipo_restricao_cor' => $restricao->getCor(),
+                        'desc_restricao' => $restricao->des_restricao . ($txt_complemento ? " — " . $txt_complemento : ""),
+                    ];
+                }
             }
         }
 
@@ -69,11 +93,27 @@ new class extends Component {
 <div>
     <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
         <div>
-            <flux:heading size="lg">Restrições de Saúde</flux:heading>
+            <div class="flex items-center gap-3">
+                <flux:heading size="lg">Restrições de Saúde</flux:heading>
+                <flux:badge size="sm" color="zinc" inset="top bottom" title="Total filtrado">{{ count($this->restricoes) }}</flux:badge>
+            </div>
             <flux:subheading>Visualize as restrições alimentares e médicas dos participantes e trabalhadores deste evento.</flux:subheading>
         </div>
-        <div class="print:hidden">
-            <flux:button onclick="window.print()" icon="printer" variant="filled">
+        <div class="flex flex-col sm:flex-row gap-2 w-full md:w-auto print:hidden">
+            <flux:select wire:model.live="tipo" icon="funnel" placeholder="Todos os tipos" class="w-full sm:w-48">
+                <option value="">Todos os tipos</option>
+                <option value="Participante">Participante</option>
+                <option value="Trabalhador">Trabalhador</option>
+            </flux:select>
+
+            <flux:input
+                wire:model.live.debounce.300ms="search"
+                icon="magnifying-glass"
+                placeholder="Nome ou apelido..."
+                class="w-full sm:w-64"
+            />
+
+            <flux:button onclick="window.print()" icon="printer" variant="outline">
                 Imprimir
             </flux:button>
         </div>
@@ -87,7 +127,7 @@ new class extends Component {
                         <tr>
                             <th class="p-4 font-bold text-zinc-950 dark:text-white print:py-2">Nome</th>
                             <th class="p-4 font-bold text-zinc-950 dark:text-white print:py-2">Tipo</th>
-                            <th class="p-4 font-bold text-zinc-950 dark:text-white print:py-2">Troca</th>
+                            <th class="p-4 font-bold text-zinc-950 dark:text-white print:py-2">Grupo</th>
                             <th class="p-4 font-bold text-zinc-950 dark:text-white print:py-2">Equipe</th>
                             <th class="p-4 font-bold text-zinc-950 dark:text-white print:py-2">Restrição</th>
                             <th class="p-4 font-bold text-zinc-950 dark:text-white print:py-2">Descrição / Detalhes</th>
@@ -104,8 +144,14 @@ new class extends Component {
                                         {{ $r->tipo_cadastro }}
                                     </flux:badge>
                                 </td>
-                                <td class="p-4 text-zinc-800 dark:text-zinc-200 font-semibold print:py-2">
-                                    {{ $r->troca }}
+                                <td class="p-4 print:py-2">
+                                    @if ($r->troca_cor)
+                                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold {{ $r->troca_cor }} print:p-0 print:bg-transparent print:text-black">
+                                            {{ $r->troca }}
+                                        </span>
+                                    @else
+                                        <span class="text-zinc-650 dark:text-zinc-400 font-semibold">{{ $r->troca }}</span>
+                                    @endif
                                 </td>
                                 <td class="p-4 text-zinc-600 dark:text-zinc-400 print:py-2">
                                     {{ $r->equipe }}

--- a/resources/views/livewire/evento/partials/trabalhadores.blade.php
+++ b/resources/views/livewire/evento/partials/trabalhadores.blade.php
@@ -9,6 +9,7 @@ new class extends Component {
 
     public Evento $evento;
     public string $search = '';
+    public string $equipeFiltroId = '';
 
     // Armazena apenas o ID, não o Model inteiro,
     // evitando o erro "Undefined array key" causado pela
@@ -88,6 +89,9 @@ new class extends Component {
                 ->where('trabalhador.idt_evento', $this->evento->idt_evento)
                 ->where('trabalhador.ind_avaliacao', false)
                 ->with(['pessoa', 'equipe'])
+                ->when($this->equipeFiltroId, function ($query) {
+                    $query->where('trabalhador.idt_equipe', $this->equipeFiltroId);
+                })
                 ->when($this->search, function ($query) {
                     $query->where(function ($q) {
                         $q->where('pessoa.nom_pessoa', 'like', '%' . $this->search . '%')
@@ -96,23 +100,34 @@ new class extends Component {
                 })
                 ->orderBy('pessoa.nom_pessoa', 'asc')
                 ->paginate(10),
+            'equipes' => \App\Models\TipoEquipe::where('idt_movimento', $this->evento->movimento->idt_movimento)->get(),
         ];
     }
 }; ?>
 
 <div class="space-y-6">
-    <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+    <div class="flex flex-col md:flex-row justify-between items-start md:items-end gap-4">
         <div>
             <flux:heading size="lg">Equipe de Trabalho</flux:heading>
             <flux:subheading>Trabalhadores pendentes de avaliação. Os já avaliados aparecem no Quadrante.</flux:subheading>
         </div>
 
-        <flux:input
-            wire:model.live.debounce.300ms="search"
-            icon="magnifying-glass"
-            placeholder="Buscar trabalhador..."
-            class="w-full md:max-w-xs"
-        />
+        <div class="flex flex-col sm:flex-row gap-2 w-full md:w-auto items-end">
+            <flux:select label="Equipe" wire:model.live="equipeFiltroId" icon="users" placeholder="Todas as equipes" class="w-full sm:w-48">
+                <option value="">Todas as equipes</option>
+                @foreach ($equipes as $equipe)
+                    <option value="{{ $equipe->idt_equipe }}">{{ $equipe->des_grupo }}</option>
+                @endforeach
+            </flux:select>
+
+            <flux:input
+                label="Busca"
+                wire:model.live.debounce.300ms="search"
+                icon="magnifying-glass"
+                placeholder="Buscar trabalhador..."
+                class="w-full sm:w-64"
+            />
+        </div>
     </div>
 
     <flux:table>
@@ -140,7 +155,12 @@ new class extends Component {
                                 size="sm"
                             />
                             <div>
-                                <div class="font-medium text-zinc-900 dark:text-white">{{ $pessoa->nom_pessoa }}</div>
+                                <div class="font-medium text-zinc-900 dark:text-white flex items-center gap-2">
+                                    <span>{{ $pessoa->nom_pessoa }}</span>
+                                    @if ($trabalhador->ind_coordenador)
+                                        <flux:icon.star variant="solid" class="size-4 text-yellow-500 shrink-0 cursor-default" title="Coordenador da Equipe" />
+                                    @endif
+                                </div>
                                 <div class="text-xs text-zinc-500">{{ $pessoa->nom_apelido }}</div>
                             </div>
                         </div>

--- a/resources/views/livewire/evento/partials/voluntarios.blade.php
+++ b/resources/views/livewire/evento/partials/voluntarios.blade.php
@@ -14,6 +14,7 @@ new class extends Component {
 
     public Evento $evento;
     public string $search = '';
+    public string $equipeFiltroId = '';
     public array $selectedEquipes = [];
     public array $indCoordenador = [];
     public array $indPrimeiraVez = [];
@@ -94,7 +95,10 @@ new class extends Component {
             'voluntarios' => \App\Models\Pessoa::query()
                 ->whereHas('voluntarios', function ($query) {
                     $query->where('idt_evento', $this->evento->idt_evento)
-                        ->whereNull('idt_trabalhador');
+                        ->whereNull('idt_trabalhador')
+                        ->when($this->equipeFiltroId, function ($q) {
+                            $q->where('idt_equipe', $this->equipeFiltroId);
+                        });
                 })
                 ->whereDoesntHave('voluntarios', function ($query) {
                     $query->where('idt_evento', $this->evento->idt_evento)
@@ -119,18 +123,28 @@ new class extends Component {
 }; ?>
 
 <div class="space-y-6">
-    <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+    <div class="flex flex-col md:flex-row justify-between items-start md:items-end gap-4">
         <div>
             <flux:heading size="lg">Triagem de Voluntários</flux:heading>
             <flux:subheading>Analise os candidatos e aloque-os nas equipes correspondentes.</flux:subheading>
         </div>
 
-        <flux:input
-            wire:model.live.debounce.300ms="search"
-            icon="magnifying-glass"
-            placeholder="Buscar por nome ou apelido..."
-            class="w-full md:max-w-xs"
-        />
+        <div class="flex flex-col sm:flex-row gap-2 w-full md:w-auto items-end">
+            <flux:select label="Equipe de interesse" wire:model.live="equipeFiltroId" icon="funnel" placeholder="Todas as equipes" class="w-full sm:w-48">
+                <option value="">Todas as equipes</option>
+                @foreach ($equipes as $equipe)
+                    <option value="{{ $equipe->idt_equipe }}">{{ $equipe->des_grupo }}</option>
+                @endforeach
+            </flux:select>
+
+            <flux:input
+                
+                wire:model.live.debounce.300ms="search"
+                icon="magnifying-glass"
+                placeholder="Nome ou apelido..."
+                class="w-full sm:w-64"
+            />
+        </div>
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">


### PR DESCRIPTION
## Contexto

O PR #63 de @gabriielk0 refatorou `TipoSituacao::badge()` e introduziu um sistema de tokens visuais mais completo. A chave `'bg'` que antes retornava cores sólidas (ex: `bg-slate-500`) passou a retornar tints claros (ex: `bg-slate-100 dark:bg-slate-900/40`).

Esse redesign é correto e intencional — porém os três formulários de ficha **não foram atualizados** e continuaram usando a chave `'bg'` combinada com `text-white`, resultando em texto branco sobre fundo claro: **texto invisível**.

## Problema

```blade
{{-- ANTES: text-white em cima de fundo claro = invisível --}}
<span class="... text-white {{ $style['bg'] }} ...">
    {{ $situacao->label() }}
</span>
```

Arquivos afetados:
- `resources/views/ficha/formVEM.blade.php` — linha 152
- `resources/views/ficha/formECC.blade.php` — linha 115
- `resources/views/ficha/formSGM.blade.php` — linha 202

## Solução

Substituição pelo token `$style['light']`, que o próprio PR #63 introduziu exatamente para este uso: um valor auto-suficiente que empacota `bg + text + border` com contraste garantido para light e dark mode.

```blade
{{-- DEPOIS: token light é auto-suficiente e semanticamente correto --}}
<span class="... {{ $style['light'] }} ...">
    {{ $situacao->label() }}
</span>
```

## Diff por arquivo

| Arquivo | Linha | Mudança |
|---------|-------|---------|
| `formVEM.blade.php` | 152 | `text-white {{ $style['bg'] }}` → `{{ $style['light'] }}` |
| `formECC.blade.php` | 115 | `text-white {{ $style['bg'] }}` → `{{ $style['light'] }}` |
| `formSGM.blade.php` | 202 | `text-white {{ $style['bg'] }}` → `{{ $style['light'] }}` |

## Como validar

1. Abrir qualquer ficha (VEM, ECC ou SGM) que tenha uma situação definida
2. Verificar que o badge de situação exibe o texto legível em modo claro
3. Alternar para modo escuro e confirmar que o contraste também está correto
4. Testar com todas as situações disponíveis (`TipoSituacao::cases()`) para garantir que todas as variações de cor estão corretas

## Cenários de teste sugeridos para o PR #63 (gabriielk0)

Além desta regressão, sugerimos os seguintes cenários de validação para as funcionalidades do PR #63:

- **Filtros da listagem de fichas**: situação (multi-select), gênero, vínculo paroquiano e vínculo por região — verificar contadores no dropdown e que a exportação respeita os filtros ativos
- **Novas colunas "Endereço" e "Vínculo"**: verificar truncamento com tooltip no endereço e exibição correta de paroquiano + região
- **Filtro de cor na aba Participantes**: cada `CorTroca` deve filtrar corretamente; contador por cor deve bater com o total de linhas
- **Filtros de equipe/grupo na aba Presença**: os dois filtros são mutuamente exclusivos — trocar um deve limpar o outro
- **Estrela de coordenador**: `ind_coordenador = 1` deve exibir ícone dourado nas abas Presença e Trabalhadores
- **Regressão de busca textual**: busca deve retornar apenas resultados que contenham o termo no nome **e** email (sem OR-leak); o fix do PR #63 agrupou a condição em closure — validar que não há resultados cruzados
- **N+1 em fichas**: com Debugbar ou Telescope, confirmar que eager loading (`evento`, `fichaVem`, `fichaEcc`, `fichaSGM`) elimina consultas N+1 na paginação

---

> **Nota**: este PR corrige exclusivamente a regressão de contraste. As demais funcionalidades do PR #63 estão corretas e foram validadas na revisão.