### PR TITLE
bug(pessoas): pré-preenche formulário de cadastro com dados do usuário autenticado

### DIFF
--- a/app/Http/Controllers/PessoaController.php
+++ b/app/Http/Controllers/PessoaController.php
@@ -65,7 +65,12 @@ class PessoaController extends Controller
         $context = $this->getLogContext(request());
         Log::info('Acesso ao formulário de criação de pessoa', $context);
 
-        $pessoa = new Pessoa;
+        $user = auth()->user();
+        $pessoa = new Pessoa([
+            'nom_pessoa' => $user->name,
+            'eml_pessoa' => $user->email,
+            'tel_pessoa' => $user->phone,
+        ]);
         $restricoes = TipoRestricao::select(
             'idt_restricao',
             'tip_restricao',

--- a/resources/views/pessoa/form.blade.php
+++ b/resources/views/pessoa/form.blade.php
@@ -18,7 +18,30 @@
 
             <form method="POST"
                 action="{{ $pessoa->exists ? route('pessoas.update', $pessoa) : route('pessoas.store') }}"
-                enctype="multipart/form-data" class="space-y-6">
+                enctype="multipart/form-data" class="space-y-6"
+                x-data="{
+                    buscarPorCpf() {
+                        let cpf = document.getElementById('num_cpf_pessoa').value.replace(/\D/g, '');
+                        if (cpf.length === 11) {
+                            fetch(`/pessoas/${cpf}/busca/`)
+                                .then(response => {
+                                    if (response.ok) return response.json();
+                                    throw new Error('Not found');
+                                })
+                                .then(data => {
+                                    document.getElementById('nom_pessoa').value = data.nom_pessoa || '';
+                                    document.getElementById('nom_apelido').value = data.nom_apelido || '';
+                                    if (data.dat_nascimento) document.getElementById('dat_nascimento').value = data.dat_nascimento.split('T')[0];
+                                    document.getElementById('tel_pessoa').value = data.tel_pessoa || '';
+                                    document.getElementById('eml_pessoa').value = data.eml_pessoa || '';
+                                    if (document.getElementById('des_endereco')) document.getElementById('des_endereco').value = data.des_endereco || '';
+                                    if (data.tam_camiseta && document.getElementById('tam_camiseta')) document.getElementById('tam_camiseta').value = data.tam_camiseta;
+                                    if (data.tip_genero && document.getElementById('tip_genero')) document.getElementById('tip_genero').value = data.tip_genero;
+                                })
+                                .catch(() => {});
+                        }
+                    }
+                }">
                 @csrf
                 @if ($pessoa->exists)
                     @method('PUT')


### PR DESCRIPTION
## Problema

Quando uma usuária sem cadastro completo clicava em **Se Voluntariar**, o sistema redirecionava para o formulário de *Completar Cadastro*, porém o formulário abria **completamente em branco** — sem preencher sequer o nome da usuária.

## Causa

`PessoaController::create()` instanciava `new Pessoa` sem parâmetros, resultando em um modelo vazio. Os campos `old('nom_pessoa', $pessoa->nom_pessoa)` na view não tinham valor para exibir.

Secundariamente, o campo CPF tinha `@blur="buscarPorCpf()"` sem nenhum elemento ancestral com `x-data` definindo a função — o Alpine.js ignorava silenciosamente o evento.

## Solução

**`app/Http/Controllers/PessoaController.php`**
- `create()` agora hidrata o modelo transiente com `auth()->user()->name`, `email` e `phone`
- Os três campos estão em `Pessoa::$fillable`, então o construtor os aceita sem persistência no banco

**`resources/views/pessoa/form.blade.php`**
- Adicionado `x-data` diretamente no elemento `<form>` com a implementação de `buscarPorCpf()`, seguindo o padrão já usado nos formulários de ficha (formVEM)

## Teste

1. Criar usuário sem `Pessoa` vinculada
2. Acessar um evento e clicar em **Se Voluntariar**
3. O sistema redireciona para *Completar Cadastro* → formulário deve abrir com nome, e-mail e telefone pré-preenchidos
4. Digitar um CPF válido e mover o foco → `buscarPorCpf()` deve buscar e preencher os campos caso o CPF já exista na base

> ⚠️ Este commit está em cima do `fix(fichas)` do PR #65. Recomenda-se mesclar o #65 antes ou mesclar este diretamente se o #65 já foi aprovado.